### PR TITLE
(hotfix) Fix entry mapping for orphan projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toggl-sync",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "main": "index.js",
   "workspaces": [

--- a/service/toggl-helpers/map-entry.ts
+++ b/service/toggl-helpers/map-entry.ts
@@ -11,11 +11,18 @@ export const mapEntryForRequest = (
   entryMappings: DynamoMapRow[],
 ): TogglEntryRequest => {
   // Unique mapping row
-  const mappingRow = entryMappings.find(
+  const projectMappingRow = entryMappings.find(
     (row) =>
       row.sourceWid === String(entry.wid) &&
-      row.sourcePid === String(entry.pid || '*'),
+      row.sourcePid === String(entry.pid),
   );
+
+  // Wildcard mapping row
+  const wildcardMappingRow = entryMappings.find(
+    (row) => row.sourceWid === String(entry.wid) && row.sourcePid === '*',
+  );
+
+  const mappingRow = projectMappingRow || wildcardMappingRow;
 
   // If row was not found, return null
   if (!mappingRow) return { __original: entry, entry: null };


### PR DESCRIPTION
Mapping failed when source contained an entry with a project ID that was not found from mappings-table. It should default to wildcard if one exists.